### PR TITLE
🐛 Rename binary to dot-browser

### DIFF
--- a/arch/dot/PKGBUILD
+++ b/arch/dot/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kieran <kieran at dothq dot co>
 pkgname=dot-bin
-_pkgname=dot
+_pkgname=dot-browser
 pkgver=0.1
 pkgrel=0
 pkgdesc="Dot Browser is a privacy-conscious web browser based on Firefox. (Binary)"
@@ -14,9 +14,9 @@ optdepends=('ffmpeg: H264/AAC/MP3 decoding'
             'pulseaudio: Audio support'
             'speech-dispatcher: Text-to-Speech'
             'hunspell-en_US: Spell checking, American English')
-provides=('dot')
-replaces=('dot')
-conflicts=('dot' 'dot-git')
+provides=('dot-browser')
+replaces=('dot-browser')
+conflicts=('dot-git')
 source=("$_pkgname-$pkgver.tar.bz2::https://download.dothq.co/dot/releases/linux/x86/raw"
         "$_pkgname.desktop"
         "$_pkgname.sh")

--- a/arch/dot/dot.desktop
+++ b/arch/dot/dot.desktop
@@ -14,8 +14,8 @@ Actions=new-window;new-private-window;
 
 [Desktop Action new-window]
 Name=New Window
-Exec=/opt/dot-bin/dot --new-window %u
+Exec=/opt/dot-bin/dot-browser --new-window %u
 
 [Desktop Action new-private-window]
 Name=New Private Window
-Exec=/opt/dot-bin/dot --private-window %u
+Exec=/opt/dot-bin/dot-browser --private-window %u


### PR DESCRIPTION
As pointed out in  dothq/browser#581 and on AUR, the `dot` binary is provided by graphviz, a library required for GIMP and GNOME builder. Given the choice between one of these tools and dot, they will likely chose these tools. This pull request changes `dot-bin` to using the `dot-browser` binary which will likely cause less conflicts.  